### PR TITLE
Add support for numpy integer and float types in tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 0.4.0
 
+### June 21, 2020
+- Tables now support every kind of int and float by using the Integral and Real types.
+- Bad indexing in Tables raises an exception.
+
 ### June 16, 2020
 - Breaking changes:
     - SelectedArea 'change_format' method removed for a 'format_spec' property and a 'apply_command' method.

--- a/python2latex/table.py
+++ b/python2latex/table.py
@@ -1,4 +1,4 @@
-from numbers import Integral
+from numbers import Real, Integral
 import numpy as np
 
 from python2latex import FloatingTable, FloatingEnvironmentMixin
@@ -153,7 +153,7 @@ class Tabular(TexEnvironment):
 
     def __setitem__(self, idx, value):
         selected_area = self[idx]
-        if isinstance(value, (str, int, float)) and selected_area.size > 1:
+        if isinstance(value, (str, Real, Integral)) and selected_area.size > 1:
             # There are multirows or multicolumns to treat
             selected_area.multicell(value)
         else:
@@ -171,15 +171,15 @@ class Tabular(TexEnvironment):
     def _format_number(self, i, j, content):
         format_spec = self.formats_spec[i, j]
 
-        if not isinstance(content, (float, int)):
+        if not isinstance(content, (Real, Integral)):
             return content
 
         if format_spec is not None:
             content = format(content, format_spec)
-        elif format_spec is None and isinstance(content, float): # Fallback to default
-            content = format(content, self.float_format)
-        elif format_spec is None and isinstance(content, int):
+        elif format_spec is None and isinstance(content, Integral):
             content = format(content, self.int_format)
+        elif format_spec is None and isinstance(content, Real): # Fallback to default
+            content = format(content, self.float_format)
 
         if self.decimal_separator != '.':
             content = content.replace('.', self.decimal_separator)
@@ -405,14 +405,14 @@ class SelectedArea:
         best_idx = [(None, None)]
         for i, row in enumerate(self.data):
             for j, value in enumerate(row):
-                if isinstance(value, (float, int)) and value_is_better_than_best(value, best_value):
+                if isinstance(value, (Real, Integral)) and value_is_better_than_best(value, best_value):
                     best_idx = [(i, j)]
                     best_value = value
 
         # Find values close to best
         for i, row in enumerate(self.data):
             for j, value in enumerate(row):
-                if isinstance(value, (float, int)) and np.isclose(value, best_value, rtol, atol) \
+                if isinstance(value, (Real, Integral)) and np.isclose(value, best_value, rtol, atol) \
                     and (i, j) not in best_idx:
                     best_idx.append((i, j))
 

--- a/python2latex/table.py
+++ b/python2latex/table.py
@@ -1,3 +1,4 @@
+from numbers import Integral
 import numpy as np
 
 from python2latex import FloatingTable, FloatingEnvironmentMixin
@@ -254,9 +255,9 @@ class SelectedArea:
             i, j = idx
         else:
             i, j = idx, slice(None)
-        if isinstance(i, int):
+        if isinstance(i, Integral):
             i = slice(i, i + 1)
-        if isinstance(j, int):
+        if isinstance(j, Integral):
             j = slice(j, j + 1)
         return i, j
 

--- a/python2latex/table.py
+++ b/python2latex/table.py
@@ -259,6 +259,8 @@ class SelectedArea:
             i = slice(i, i + 1)
         if isinstance(j, Integral):
             j = slice(j, j + 1)
+        if not isinstance(i, slice) or not isinstance(i, slice):
+            raise ValueError(f'Invalid index {idx}. It should be an integral, a slice or a tuple of intregrals or slices.')
         return i, j
 
     @property

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -114,6 +114,7 @@ class TestSelectedArea:
             (slice(None), slice(None)),
             (1, slice(None)),
             (slice(1, 3)),
+            (np.int64(1), np.int64(2)),
         ]
         expected_values = [
             (slice(1, 2), slice(2, 3)),
@@ -121,6 +122,7 @@ class TestSelectedArea:
             (slice(None), slice(None)),
             (slice(1, 2), slice(None)),
             (slice(1, 3), slice(None)),
+            (slice(1, 2), slice(2, 3)),
         ]
         for idx, expected_value in zip(indices, expected_values):
             assert self.row_area._convert_idx_to_slice(idx) == expected_value

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,6 +1,6 @@
 from inspect import cleandoc
 
-from pytest import fixture
+from pytest import fixture, raises
 
 from python2latex.table import *
 from python2latex.tex_base import bold, italic
@@ -126,6 +126,9 @@ class TestSelectedArea:
         ]
         for idx, expected_value in zip(indices, expected_values):
             assert self.row_area._convert_idx_to_slice(idx) == expected_value
+
+        with raises(ValueError):
+            self.row_area._convert_idx_to_slice((np.array(1), np.array(2)))
 
     def test_idx(self):
         assert self.whole_table_area.idx == ((0, 0), (3, 3))


### PR DESCRIPTION
When using numpy integer, it didn't work for instance when applying a command on the selection.